### PR TITLE
Bug: Details screens not showing when selecting plan/task

### DIFF
--- a/grant/windows/filter_selection_screen.py
+++ b/grant/windows/filter_selection_screen.py
@@ -58,7 +58,7 @@ class FilterSelectionScreen(SelectionScreen):
 
     def selection_changed(self, selected, _):
         """ Handle changed selection """
-        if len(selected.indexes()) != 1:
+        if len(selected.indexes()) < 1:
             return
         index = selected.indexes()[0]
         flat_index = self.tasks_model.mapToSource(index)

--- a/grant/windows/tree_selection_screen.py
+++ b/grant/windows/tree_selection_screen.py
@@ -56,7 +56,7 @@ class TreeSelectionScreen(SelectionScreen):
 
     def selection_changed(self, selected, _):
         """ Handle changed selection """
-        if len(selected.indexes()) != 1:
+        if len(selected.indexes()) < 1:
             return
         index = selected.indexes()[0]
         self.item_selected.emit(index)


### PR DESCRIPTION
* When selecting a plan or task in tree or filter view, the details screen wasn't shown
* Check that there is at least one selected index and take the first one.