### PR TITLE
Listen to rowsRemoved signals in TableModel

### DIFF
--- a/grant/models/table_model.py
+++ b/grant/models/table_model.py
@@ -47,6 +47,7 @@ class TableModel(QAbstractProxyModel):
         self.sourceModel().dataChanged.connect(self.sourceDataChanged)
         self.sourceModel().modelReset.connect(self.reset_model)
         self.sourceModel().layoutChanged.connect(self.reset_model)
+        self.sourceModel().rowsRemoved.connect(self.reset_model)
 
     def mapFromSource(self, index):  # pylint: disable=invalid-name
         """ map given index from Tree to Flat """


### PR DESCRIPTION
* After deleting a plan or a task, switching to the filter view would crash
* This is because the `TableModel` did not listen to the `rowsRemoved` signal and thus didn't update its internal state from the `TreeModel`
* Added a connection to the signals to reset the model's internal state.